### PR TITLE
Use using instead of typedef

### DIFF
--- a/idioms/threadraii.cpp
+++ b/idioms/threadraii.cpp
@@ -2,7 +2,7 @@
 
 class ThreadRAII {
 public:
-  typedef void (std::thread::*RAIIAction)();  // dtor action
+  using RAIIAction = void (std::thread::*)();  // dtor action
   ThreadRAII(std::thread&& thread, RAIIAction a)
     : t(std::move(thread)), action(a) {}
 


### PR DESCRIPTION
I think put using instead of typedef can make code more readable.